### PR TITLE
Drl 50 dev- autoCreateCampaignMember

### DIFF
--- a/force-app/main/default/classes/DRL_LeadTriggerHelper.cls
+++ b/force-app/main/default/classes/DRL_LeadTriggerHelper.cls
@@ -1,43 +1,34 @@
 /*******************************************************************************************************
 * 
 * @ Name            :   DRL_LeadTriggerHelper
-* @ Purpose         :   Helper class for LeadTrigger to handle all the operations on Lead
-* @ Author          :   Deeksha Suvarna
+* @ Purpose         :   Apex class for prospect creation and field updation.
+* @ Author          :   Ankit C
 * @ Usage           :   1) If Prospect exist - link it to child lead.
                         2) If Prospect does not exist - Create prospect and link it to child.
 * @ Test Class Name :   
 *
-*   Date            |  Developer Name                |  Version    |    Changes    
-* ======================================================================================================        
-*  02-11-2022       |  deeksha.suvarna@absyz.com     |  1.0        |    Initial Version   
+*   Date            |  Developer Name							|  Version        
+* ======================================================================================================
+*  02-11-2022       |  ankit.c@absyz.com						|  1.0          
+*  03-11-2022       |  deeksha.suvarna@absyz.com				|  2.0  
+*  07-11-2022       |  mahalakshmi.sadhanantham@absyz.com		|  3.0  
 *******************************************************************************************************/
 public without sharing class DRL_LeadTriggerHelper {
     public static Boolean blnSkipTrigger = false;
     public static void processAfterInsert(List<Lead> list_Leads) {
-        Schema.DescribeSObjectResult objDescribeSObjectResult = Lead.sObjectType.getDescribe();
-        // Map of existing Leads by Email
-        Map<String, Lead> map_ExistingLeadByEmail = new Map<String, Lead>();
-        //Map of Record Type Id by Developer Name
+        Schema.DescribeSObjectResult strDescription = Lead.sObjectType.getDescribe();
+        Map<String, Schema.FieldSet> map_LeadFieldSet = strDescription.fieldSets.getMap();
+        List<FieldSetMember> list_LeadFieldSetMember = map_LeadFieldSet.get('DRL_ProspectFields').getFields();
+        List<Schema.sObjectField> list_LeadsObjectField = new List<Schema.sObjectField>();
+        Map<String, Lead> map_LeadByEmail = new Map<String, Lead>();
         Map<String, Id> map_RecordTypeIdByDeveloperName = DRLUtil.getRecordTypeDeveloperNameIdMap('Lead');
-        //Map of Lead(Prospect) by their Email to be inserted
-        Map<String, Lead> map_LeadByEmailToInsert = new Map<String, Lead>();
-        //List of all the Errors occurred during DML operation
-        List<String> list_ConsolidatedDMLErrors = new List<String>();
-        //Map of Lead Field Set by their Name
-        Map<String, Schema.FieldSet> map_LeadFieldSetByName = objDescribeSObjectResult.fieldSets.getMap();
-        //List of Lead Field Set Members
-        List<FieldSetMember> list_LeadFieldSetMembers = map_LeadFieldSetByName.containsKey('DRL_ProspectFields')
-                                                            ? map_LeadFieldSetByName.get('DRL_ProspectFields').getFields()
-                                                            : new List<FieldSetMember>();
-        //List of Fields in the Field Set
-        List<Schema.SObjectField> list_LeadObjectFields = new List<Schema.SObjectField>();
-        //List of Incoming Lead with no existing Prospect
+        Map<String, Lead> map_LeadsToInsert = new Map<String, Lead>();
         List<Lead> list_ChildLeads = new List<Lead>();
-        //List of Lead to be updated
+        List<CampaignMember> list_CampaignMembers = new List<CampaignMember>();
         List<Lead> list_LeadsToUpdate = new List<Lead>();
-
-        for (FieldSetMember objFieldSetMember : list_LeadFieldSetMembers) {
-            list_LeadObjectFields.add(objFieldSetMember.getSObjectField()); 
+        for (FieldSetMember objFields : list_LeadFieldSetMember) {
+            list_LeadsObjectField.add(objFields.getSObjectField());
+            
         }
 
         for (Lead objLead : [SELECT 
@@ -47,89 +38,101 @@ public without sharing class DRL_LeadTriggerHelper {
                              Lead
                              WHERE RecordTypeId = :map_RecordTypeIdByDeveloperName.get('DRL_Prospect')
                              AND Id NOT IN :list_Leads
-                             AND Email != null
-                             ]
-        ) {
-            map_ExistingLeadByEmail.put(objLead.Email, objLead);                    
+                             AND Email !=null
+           
+        ]) {
+            map_LeadByEmail.put(objLead.Email, objLead);                    
         }
         
-        try {
+        try{
             for (Lead objLead : list_Leads) {
-                if (!map_ExistingLeadByEmail.containsKey(objLead.Email)) {
-                    //Creating Prospect if it's not existing in the system
+                if (!map_LeadByEmail.containsKey(objLead.Email)) {
+                    //create prospect lead
                     Map<String, Object> map_LeadFieldByName = objLead.getPopulatedFieldsAsMap();
                     Lead objProspect = new Lead();
-                    for (Schema.SObjectField objSObjectField : list_LeadObjectFields) {
-                        Schema.DescribeFieldResult objDescribeFieldResult = objSObjectField.getDescribe();
-                        String strFieldAPIName = objDescribeFieldResult.getName();
-                        if (map_LeadFieldByName.containsKey(strFieldAPIName)) {
-                            objProspect.put(strFieldAPIName, map_LeadFieldByName.get(strFieldAPIName));
-                        }
+                    for( Schema.sObjectField objField : list_LeadsObjectField){
+                        Schema.DescribeFieldResult dfr = objField.getDescribe();
+                        string APIName = dfr.getName();
+                        objProspect.put(APIName,map_LeadFieldByName.get(APIName));
                     }
-
-                    if (map_RecordTypeIdByDeveloperName.containsKey('DRL_Prospect')) {
-                        objProspect.RecordTypeId = map_RecordTypeIdByDeveloperName.get('DRL_Prospect'); 
-                    }
-
-                    map_LeadByEmailToInsert.put(objProspect.Email, objProspect);
+                    objProspect.RecordTypeId = map_RecordTypeIdByDeveloperName.get('DRL_Prospect');
+                    /*Lead objProspect = new Lead(
+                        FirstName = objLead.FirstName,
+                        LastName = objLead.LastName,
+                        Company = objLead.Company,
+                        Email = objLead.Email,
+                        RecordTypeId = map_RecordTypeIdByDeveloperName.get('DRL_Prospect')
+                    );*/
+                    map_LeadsToInsert.put(objProspect.Email, objProspect);
                     list_ChildLeads.add(objLead);
+                    system.debug('map_LeadFieldSet'+map_LeadFieldSet);
+                    system.debug('strDescription'+strDescription);
+                    system.debug('list_LeadFieldSetMember'+list_LeadFieldSetMember);
+                    system.debug('list_LeadsObjectField'+list_LeadsObjectField);
+                    system.debug('list_LeadsObjectField'+list_LeadsObjectField);
                 } else {
                     Lead objLeadToUpdate = new Lead(Id = objLead.Id);
-                    objLeadToUpdate.DRL_Prospect__c = map_ExistingLeadByEmail.get(objLead.Email).Id;
+                    objLeadToUpdate.DRL_Prospect__c = map_LeadByEmail.get(objLead.Email).Id;
                     objLeadToUpdate.DRL_Email__c = objLead.Email;
                     objLeadToUpdate.Email = null;
-
-                    if (map_RecordTypeIdByDeveloperName.containsKey('DRL_Lead')) {
-                        objLeadToUpdate.RecordTypeId = map_RecordTypeIdByDeveloperName.get('DRL_Lead');
-                    }
-
+                    objLeadToUpdate.RecordTypeId = map_RecordTypeIdByDeveloperName.get('DRL_Lead');
                     list_LeadsToUpdate.add(objLeadToUpdate);
                 }
             }
             
             DRL_LeadTriggerHelper.blnSkipTrigger = true;
+            // insert map_LeadsToInsert.values();
             
             for (Lead objLead : list_ChildLeads) {
                 Lead objLeadToUpdate = new Lead(Id = objLead.Id);
+                // if (map_LeadsToInsert.containsKey(objLead.Email)) {
+                //     //objLeadToUpdate.DRL_Prospect__c = map_LeadsToInsert.get(objLead.Email).Id;
+                // }
                 objLeadToUpdate.DRL_Email__c = objLead.Email;
                 objLeadToUpdate.Email = null;
-
-                if (map_RecordTypeIdByDeveloperName.containsKey('DRL_Lead')) {
-                    objLeadToUpdate.RecordTypeId = map_RecordTypeIdByDeveloperName.get('DRL_Lead');
-                }
-
+                objLeadToUpdate.RecordTypeId = map_RecordTypeIdByDeveloperName.get('DRL_Lead');
                 list_LeadsToUpdate.add(objLeadToUpdate);
             }
-
-            if (!list_LeadsToUpdate.isEmpty()) {
-                if (Test.isRunningTest() && DRL_LeadTriggerHelperTest.blnThrowException) {
-                    throw new DMLException();
-                } 
-
-                //Update Email field
-                List<Database.SaveResult> list_UpdateLeadResults = Database.update(list_LeadsToUpdate, false);
-                list_ConsolidatedDMLErrors.addAll(DRLUtil.processDMLErrors(list_UpdateLeadResults, 'Update'));
-            }
             
-            //Create Parent Prospect Record
-            if (!map_LeadByEmailToInsert.isEmpty()) {
-                List<Database.SaveResult> list_InsertResults = Database.insert(map_LeadByEmailToInsert.values(), false);
-                list_ConsolidatedDMLErrors.addAll(DRLUtil.processDMLErrors(list_InsertResults, 'Insert'));
-            }
+            update list_LeadsToUpdate;
+            insert map_LeadsToInsert.values();
 
             for (Lead objLead : list_LeadsToUpdate) {
-                if (objLead.DRL_Prospect__c == null && map_LeadByEmailToInsert.containsKey(objLead.DRL_Email__c)) {
-                    objLead.DRL_Prospect__c = map_LeadByEmailToInsert.get(objLead.DRL_Email__c).Id;
+                if (objLead.DRL_Prospect__c == null && map_LeadsToInsert.containsKey(objLead.DRL_Email__c)) {
+                    objLead.DRL_Prospect__c = map_LeadsToInsert.get(objLead.DRL_Email__c).Id;
                 }
             }
+            
+            update list_LeadsToUpdate;
+            /*
+             * DRL-50
+              *When a Source Campaign record is linked to the Child lead record, create a Campaign member record.
+              *For new Campaign member record, populate
+              *Campaign: Source campaign value on the child lead record.
+              *Lead: Prospect parent record of the child lead record.
+            */
+            list_LeadsToUpdate = [SELECT 
+                                  Id,
+                                  RecordTypeId,
+                                  DRL_Prospect__c,
+                                  DRL_Source_Campaign__c 
+                                  FROM Lead 
+                                  WHERE Id 
+                                  IN :list_LeadsToUpdate];
+                for( Lead objLead : list_LeadsToUpdate){
+                    if( 
+                        objLead.RecordTypeId == map_RecordTypeIdByDeveloperName.get('DRL_Lead') &&
+                        objLead.DRL_Source_Campaign__c!=null && objLead.DRL_Prospect__c != null
+                    ){
+                        CampaignMember objCampaignMember = new CampaignMember();
+                        objCampaignMember.CampaignId = objLead.DRL_Source_Campaign__c;
+                        objCampaignMember.LeadId = objLead.DRL_Prospect__c; 
+                        list_CampaignMembers.add(objCampaignMember);
+                    }
+                }
+                List<Database.SaveResult> list_Results = Database.insert(list_CampaignMembers, false);
+                DRL_LeadTriggerHelper.blnSkipTrigger = false;
 
-            if (!list_LeadsToUpdate.isEmpty()) {
-                //Link it to Child
-                List<Database.SaveResult> list_UpdateResults = Database.update(list_LeadsToUpdate,false);
-                list_ConsolidatedDMLErrors.addAll(DRLUtil.processDMLErrors(list_UpdateResults, 'Update'));
-            }
-
-            DRL_LeadTriggerHelper.blnSkipTrigger = false;
         } catch(Exception objException) {
             DRLUtil.logException(
                 'DRL_LeadTriggerHelper',
@@ -138,5 +141,75 @@ public without sharing class DRL_LeadTriggerHelper {
                 true
             );
         }
-    } 
+    }
+    
+  
+    
+    /*
+     * DRL - 48
+     * Check if the utm Source Campaign code on incoming lead record is matching with Campaign code on Campaign records.
+     * If the match exist then update the Source Campaign field on the (child) lead record with the matched Campaign record.
+	 *
+     * DRL - 49
+     * Check if the utm Source code on incoming lead record is matching with the custom metadata UTM Source records with parameter Lable.
+     * If the match exist then the matched record Lead Source value to be updated on the Lead record Lead Source field.
+	 */
+    public static void populateSourceCampaign(List<Lead> list_leads){
+        //Attributes for DRL-48
+        set<String> set_CampaignCodes = new set<String>();
+        map<String,Id> map_CampaignCodeWithCampaignID = new map<String,Id>();
+        //Attributes for DRL-49
+        set<String> set_SourceCodes = new set<String>();
+        map<String,String> map_UtmSourcelablewithLeadSource = new map<String,String>();
+        
+        //Fetch campaign codes from Lead records in a SET(set_CampaignCodes)
+        for(Lead objLead : list_leads){
+            if(objLead.DRL_UTM_Campaign__c!=null){
+               set_CampaignCodes.add(objLead.DRL_UTM_Campaign__c);
+            }
+            
+            //DRL-49 Fetch source codes from Lead records in a SET(set_SourceCodes)
+            if(objLead.DRL_UTM_Source__c!=null ){
+                set_SourceCodes.add(objLead.DRL_UTM_Source__c);
+            }
+        }
+        
+        //Fetch campaign records which are in the set_CampaignCodes in a MAP(map_CampaignCodeWithCampaignID)
+        for(Campaign objCampaign : [SELECT 
+                                    Id, 
+                                    Name,
+                                    DRL_CampaignCode__c 
+                                    FROM Campaign 
+                                    WHERE DRL_CampaignCode__c IN: set_CampaignCodes 
+                                    AND IsActive = true]){
+                                        if(!map_CampaignCodeWithCampaignID.containsKey(objCampaign.DRL_CampaignCode__c)){
+                                            map_CampaignCodeWithCampaignID.put(objCampaign.DRL_CampaignCode__c,objCampaign.Id);
+                                        }
+                                    }
+        //DRL-49 Fetch Lable and LeadSource__c from UTM Source metadata records in a MAP(map_UtmSourcelablewithLeadSource)
+        for(DRL_UTMSource__mdt mdtUTMsource : [SELECT
+                                               Id,
+                                               label,
+                                               LeadSource__c 
+                                               FROM DRL_UTMSource__mdt 
+                                               WHERE label IN: set_SourceCodes ]){
+                                                   if(!map_UtmSourcelablewithLeadSource.containsKey(mdtUTMsource.Label)){
+                                                       map_UtmSourcelablewithLeadSource.put(mdtUTMsource.Label,mdtUTMsource.LeadSource__c);
+
+                                                   }
+                                               }
+        
+        //Assign the fetched campaign records to the Source campaign field on the Lead records
+        for(Lead objLead : list_leads){
+            if(map_CampaignCodeWithCampaignID.containsKey(objLead.DRL_UTM_Campaign__c)){
+                objLead.DRL_Source_Campaign__c = map_CampaignCodeWithCampaignID.get(objLead.DRL_UTM_Campaign__c);
+            }
+            
+            //DRL-49 Assign the fetched Lead source to the Lead record LeadSource field
+            if(map_UtmSourcelablewithLeadSource.containsKey(objLead.DRL_UTM_Source__c)){
+                objLead.LeadSource = map_UtmSourcelablewithLeadSource.get(objLead.DRL_UTM_Source__c);
+            }
+        }
+    }  
+    
 }

--- a/force-app/main/default/classes/DRL_LeadTriggerHelper.cls
+++ b/force-app/main/default/classes/DRL_LeadTriggerHelper.cls
@@ -12,6 +12,7 @@
 *  02-11-2022       |  ankit.c@absyz.com						|  1.0          
 *  03-11-2022       |  deeksha.suvarna@absyz.com				|  2.0  
 *  07-11-2022       |  mahalakshmi.sadhanantham@absyz.com		|  3.0  
+*  09-11-2022       |  dinesh.chandra@absyz.com	            	|  4.0  
 *******************************************************************************************************/
 public without sharing class DRL_LeadTriggerHelper {
     public static Boolean blnSkipTrigger = false;

--- a/force-app/main/default/classes/DRL_LeadTriggerHelperTest.cls
+++ b/force-app/main/default/classes/DRL_LeadTriggerHelperTest.cls
@@ -4,10 +4,10 @@
 * @ Purpose         :   Test class for DRL_LeadTriggerHelper
 * @ Author          :   Deeksha Suvarna
 *
-*   Date            |  Developer Name               |  Version      |  Changes
+*   Date            |  Developer Name						|  Version      |  Changes
 * ======================================================================================================
-*   04-11-2022      |  deeksha.suvarna@absyz.com    |  1.0          |  Initial Version
-*
+*   04-11-2022      |  deeksha.suvarna@absyz.com    		|  1.0          |  Initial Version
+*   08-11-2022      |  mahalakshmi.sadhanantham@absyz.com	|  2.0          |  Campaign record creation
 *******************************************************************************************************/
 @isTest
 public class DRL_LeadTriggerHelperTest {
@@ -17,13 +17,28 @@ public class DRL_LeadTriggerHelperTest {
     * @ description  :  This method is used to setup data for testing apex class 'DRL_LeadTriggerHelper'
     **/
     @TestSetup
-    static void createData() {
+    static void createData(){
+        /**
+    	* @ author       :  Mahalakshmi S
+    	* @ description  :  This method is used to setup data for testing apex class 'DRL_LeadTriggerHelper', for Story DRL-48
+	    **/
+        Campaign objCampaign = new DRL_TestUtility.CampaignBuilder()
+            .setCampaignName('Test Campaign')
+            .setAllowMassEmail('No')
+            .setDescription('Test Campaign Description')
+            .setCampaignCode('Campaign 1005')
+            .setIsActive(true)
+            .createCampaign();
+        insert objCampaign;
+        
         Map<String, Id> map_RecordTypeIdByDeveloperName = DRLUtil.getRecordTypeDeveloperNameIdMap('Lead');
         Lead objLead = new DRL_TestUtility.LeadBuilder()
             .setFirstName('Test')
             .setLastName('User')
             .setEmail('testuser@yopmail.com')
             .setCompany('Absyz')
+            .setUtmCampaign('Campaign 1005')
+            .setUtmSorce('Test MDT 2')
             .setRecordTypeId(map_RecordTypeIdByDeveloperName.get('DRL_Lead'))
             .createLead();
         insert objLead;
@@ -56,6 +71,7 @@ public class DRL_LeadTriggerHelperTest {
         System.assert(!list_leads.isEmpty(), 'Prospect was not created!');
     }
 
+    
     /**
     * @ author       :  Deeksha Suvarna
     * @ description  :  This method is used to test the condition - Prospect exist, Child lead record is created,.  
@@ -85,7 +101,7 @@ public class DRL_LeadTriggerHelperTest {
                                 FROM Lead
                                 WHERE RecordTypeId = :map_RecordTypeIdByDeveloperName.get('DRL_Lead') 
                                 AND DRL_Email__c = 'testuser@yopmail.com'
-                                AND DRL_Prospect__c = :objLead.Id];
+                                AND DRL_Prospect__c =: objLead.Id];
         System.assert(!list_leads.isEmpty(), 'Lead failed to get linked to existing Prospect!');
     }
 

--- a/manifest/package.xml
+++ b/manifest/package.xml
@@ -1,20 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Package xmlns="http://soap.sforce.com/2006/04/metadata">
 	<types>
-		<members>DRLUtil</members>
 		<members>DRL_LeadTriggerHelper</members>
 		<members>DRL_LeadTriggerHelperTest</members>
-		<members>DRL_TestUtility</members>
-		<members>LeadTriggerHandler</members>
 		<name>ApexClass</name>
 	</types>
 	<types>
 		<members>LeadTrigger</members>
 		<name>ApexTrigger</name>
-	</types>
-	<types>
-		<members>Lead.DRL_ProspectFields</members>
-		<name>FieldSet</name>
 	</types>
 	<version>55.0</version>
 </Package>


### PR DESCRIPTION
From Line 108 in DRL_LeadTriggerHelper Class
When a Source Campaign record is linked to the Child lead record, create a Campaign member record.

For new Campaign member record, populate
Campaign: Source campaign value on the child lead record.
Lead: Prospect parent record of the child lead record.